### PR TITLE
Media improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,9 @@
     "drupal/focal_point": "1.x-dev",
     "enyo/dropzone": "^5.5",
     "drupal/media_entity_browser": "2.x-dev",
-    "drupal/entity_embed": "1.x-dev"
+    "drupal/entity_embed": "1.x-dev",
+    "drupal/media_entity_facebook": "^2.0@alpha",
+    "drupal/media_entity_twitter": "2.0-alpha2"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.8",

--- a/config/install/core.entity_form_display.media.facebook_post.default.yml
+++ b/config/install/core.entity_form_display.media.facebook_post.default.yml
@@ -1,0 +1,72 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.field.media.facebook_post.field_media_facebook
+    - media.type.facebook_post
+  module:
+    - content_moderation
+    - path
+id: media.facebook_post.default
+targetEntityType: media
+bundle: facebook_post
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_media_facebook:
+    weight: 0
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    settings: {  }
+    region: content
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 100
+    region: content
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/config/install/core.entity_form_display.media.facebook_post.default.yml
+++ b/config/install/core.entity_form_display.media.facebook_post.default.yml
@@ -5,7 +5,6 @@ dependencies:
     - field.field.media.facebook_post.field_media_facebook
     - media.type.facebook_post
   module:
-    - content_moderation
     - path
 id: media.facebook_post.default
 targetEntityType: media

--- a/config/install/core.entity_form_display.media.tweet.default.yml
+++ b/config/install/core.entity_form_display.media.tweet.default.yml
@@ -5,7 +5,6 @@ dependencies:
     - field.field.media.tweet.field_media_twitter
     - media.type.tweet
   module:
-    - content_moderation
     - path
 id: media.tweet.default
 targetEntityType: media

--- a/config/install/core.entity_form_display.media.tweet.default.yml
+++ b/config/install/core.entity_form_display.media.tweet.default.yml
@@ -1,0 +1,72 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.field.media.tweet.field_media_twitter
+    - media.type.tweet
+  module:
+    - content_moderation
+    - path
+id: media.tweet.default
+targetEntityType: media
+bundle: tweet
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_media_twitter:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    settings: {  }
+    region: content
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 100
+    region: content
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/config/install/core.entity_view_display.media.facebook_post.default.yml
+++ b/config/install/core.entity_view_display.media.facebook_post.default.yml
@@ -1,0 +1,26 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.field.media.facebook_post.field_media_facebook
+    - media.type.facebook_post
+  module:
+    - media_entity_facebook
+id: media.facebook_post.default
+targetEntityType: media
+bundle: facebook_post
+mode: default
+content:
+  field_media_facebook:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: facebook_embed
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/install/core.entity_view_display.media.remote_video.default.yml
+++ b/config/install/core.entity_view_display.media.remote_video.default.yml
@@ -3,55 +3,24 @@ status: true
 dependencies:
   config:
     - field.field.media.remote_video.field_media_oembed_video
-    - image.style.thumbnail
     - media.type.remote_video
   module:
     - media
-    - svg_image
-    - user
 id: media.remote_video.default
 targetEntityType: media
 bundle: remote_video
 mode: default
 content:
-  created:
-    label: hidden
-    type: timestamp
-    weight: 0
-    region: content
-    settings:
-      date_format: medium
-      custom_date_format: ''
-      timezone: ''
-    third_party_settings: {  }
   field_media_oembed_video:
     type: oembed
-    weight: 6
-    label: above
+    weight: 0
+    label: hidden
     settings:
       max_width: 0
       max_height: 0
     third_party_settings: {  }
     region: content
-  thumbnail:
-    type: image
-    weight: 5
-    label: hidden
-    settings:
-      image_style: thumbnail
-      svg_attributes:
-        width: ''
-        height: ''
-      svg_render_as_image: true
-      image_link: ''
-    region: content
-    third_party_settings: {  }
-  uid:
-    label: hidden
-    type: author
-    weight: 0
-    region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
+  created: true
   name: true
+  thumbnail: true

--- a/config/install/core.entity_view_display.media.tweet.default.yml
+++ b/config/install/core.entity_view_display.media.tweet.default.yml
@@ -1,0 +1,26 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.field.media.tweet.field_media_twitter
+    - media.type.tweet
+  module:
+    - media_entity_twitter
+id: media.tweet.default
+targetEntityType: media
+bundle: tweet
+mode: default
+content:
+  field_media_twitter:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: twitter_embed
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/install/entity_browser.browser.media_entity_browser.yml
+++ b/config/install/entity_browser.browser.media_entity_browser.yml
@@ -2,7 +2,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - media.type.image
     - views.view.media_entity_browser
   module:
     - dropzonejs_eb_widget

--- a/config/install/entity_browser.browser.media_entity_browser.yml
+++ b/config/install/entity_browser.browser.media_entity_browser.yml
@@ -2,9 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
+    - media.type.image
     - views.view.media_entity_browser
   module:
     - dropzonejs_eb_widget
+    - entity_browser_entity_form
     - media
     - views
 name: media_entity_browser
@@ -27,7 +29,7 @@ widgets:
       submit_text: 'Select media'
       auto_select: false
     uuid: 6586703a-6976-4124-8a49-cbb07ceaa3b1
-    weight: -8
+    weight: -9
     label: 'Choose existing media'
     id: view
   e43a6261-491b-400b-a277-832740af37bd:
@@ -49,3 +51,33 @@ widgets:
     weight: -10
     label: 'Upload new image'
     id: dropzonejs_media_entity_inline_entity_form
+  18399d8f-424b-4609-9523-aba1075c7ea2:
+    settings:
+      entity_type: media
+      bundle: facebook_post
+      form_mode: default
+      submit_text: 'Embed post'
+    uuid: 18399d8f-424b-4609-9523-aba1075c7ea2
+    weight: -7
+    label: 'Add facebook post'
+    id: entity_form
+  305d23ca-c57c-47a4-9369-50e99047053b:
+    settings:
+      entity_type: media
+      bundle: tweet
+      form_mode: default
+      submit_text: 'Embed tweet'
+    uuid: 305d23ca-c57c-47a4-9369-50e99047053b
+    weight: -6
+    label: 'Add tweet'
+    id: entity_form
+  c74e2588-dde2-4ee0-89b2-6bbcd69fcdcc:
+    settings:
+      entity_type: media
+      bundle: remote_video
+      form_mode: default
+      submit_text: 'Embed video'
+    uuid: c74e2588-dde2-4ee0-89b2-6bbcd69fcdcc
+    weight: -8
+    label: 'Add remote video'
+    id: entity_form

--- a/config/install/field.field.media.facebook_post.field_media_facebook.yml
+++ b/config/install/field.field.media.facebook_post.field_media_facebook.yml
@@ -1,0 +1,18 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_facebook
+    - media.type.facebook_post
+id: media.facebook_post.field_media_facebook
+field_name: field_media_facebook
+entity_type: media
+bundle: facebook_post
+label: Facebook
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/install/field.field.media.tweet.field_media_twitter.yml
+++ b/config/install/field.field.media.tweet.field_media_twitter.yml
@@ -1,0 +1,18 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_media_twitter
+    - media.type.tweet
+id: media.tweet.field_media_twitter
+field_name: field_media_twitter
+entity_type: media
+bundle: tweet
+label: 'Tweet URL'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/field.storage.media.field_media_facebook.yml
+++ b/config/install/field.storage.media.field_media_facebook.yml
@@ -1,0 +1,18 @@
+langcode: es
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_media_facebook
+field_name: field_media_facebook
+entity_type: media
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.media.field_media_twitter.yml
+++ b/config/install/field.storage.media.field_media_twitter.yml
@@ -1,0 +1,20 @@
+langcode: es
+status: true
+dependencies:
+  module:
+    - media
+id: media.field_media_twitter
+field_name: field_media_twitter
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/media.type.facebook_post.yml
+++ b/config/install/media.type.facebook_post.yml
@@ -1,0 +1,14 @@
+langcode: es
+status: true
+dependencies:
+  module:
+    - media_entity_facebook
+id: facebook_post
+label: 'Facebook Post'
+description: ''
+source: facebook
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  source_field: field_media_facebook
+field_map: {  }

--- a/config/install/media.type.tweet.yml
+++ b/config/install/media.type.tweet.yml
@@ -1,0 +1,20 @@
+langcode: es
+status: true
+dependencies:
+  module:
+    - media_entity_twitter
+id: tweet
+label: Tweet
+description: ''
+source: twitter
+queue_thumbnail_downloads: false
+new_revision: false
+source_configuration:
+  source_field: field_media_twitter
+  use_twitter_api: false
+  generate_thumbnails: false
+  consumer_key: ''
+  consumer_secret: ''
+  oauth_access_token: ''
+  oauth_access_token_secret: ''
+field_map: {  }

--- a/trichechus.info.yml
+++ b/trichechus.info.yml
@@ -40,6 +40,8 @@ dependencies:
   - inline_entity_form
   - link
   - media_entity_browser
+  - media_entity_facebook
+  - media_entity_twitter
   - menu_link_content
   - menu_ui
   - metatag


### PR DESCRIPTION
## Description
To make the media config more robust and allow users to do more things we are including in Trichechus the following changes:
- the media_entity_facebook and media_entity_twitter modules,
- a new media type for facebook posts,
- a new media type for tweets,
- the default display mode of remote videos media type now shows just the video instead of all its information,
- the media_entity_browser now  includes tabs for adding remote videos, facebook posts and tweets (in addition to the already supported "Choose existing media" and "Upload new image").

## Steps to test
- Install a site using Trichechus profile.
- Create a new content type with title and body.
- In the body field, if you use the format "Full HTML" there should be a button "E" for embedding media, if you click on that button you should see a modal with tabs for 
  - "Upload new image", 
  - "Choose existing media", 
  - "Add remote video", 
  - "Add facebook post" and 
  - "Add tweet".
- Try to embed each type of media, it should work without errors.

Note: in order to add tweets you don't need to add the embed code, just the tweet URL.