### PR TITLE
Updated admin_toolbar module from 1.24 to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "cweagans/composer-patches": "~1.0",
     "drupal/pathauto": "^1.3",
     "drupal/devel": "^2.0",
-    "drupal/admin_toolbar": "^1.24",
+    "drupal/admin_toolbar": "^2.0",
     "drupal/rabbit_hole": "1.x-dev",
     "drupal/twig_tweak": "^2.1",
     "drupal/svg_image": "^1.8",


### PR DESCRIPTION
Updated admin_toolbar module because the version 1 of the module is without support
