### PR TITLE
AS-82: Add missing config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
     "drupal/shs": "^1.0",
     "drupal/analytics": "^1.0",
     "drupal/warmer": "^1.1",
-    "drupal/search_api_solr": "^3.9",
+    "drupal/search_api_solr": "^4.0",
     "drupal/redis": "^1.4",
     "drupal/url_embed": "^1.0",
     "drupal/layout_builder_restrictions": "^2.7",
@@ -88,6 +88,7 @@
   },
   "extra": {
     "enable-patching": true,
+    "composer-exit-on-patch-failure": true,
     "patches": {
       "drupal/entity_browser": {
         "Patch entity browser to fix incorrect configuration": "https://www.drupal.org/files/issues/2845037_15.patch"

--- a/config/install/components.settings.yml
+++ b/config/install/components.settings.yml
@@ -1,2 +1,2 @@
-namespace_prefix: 0
+namespace_prefix: false
 

--- a/config/install/config_split.config_split.dev.yml
+++ b/config/install/config_split.config_split.dev.yml
@@ -7,7 +7,6 @@ description: ''
 folder: sites/default/config/dev
 module:
   devel: 0
-  field_ui: 0
   kint: 0
   views_ui: 0
 theme: {  }

--- a/config/install/language.content_settings.path_alias.path_alias.yml
+++ b/config/install/language.content_settings.path_alias.path_alias.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - path_alias
+id: path_alias.path_alias
+target_entity_type_id: path_alias
+target_bundle: path_alias
+default_langcode: und
+language_alterable: true

--- a/config/install/language.content_settings.redirect.redirect.yml
+++ b/config/install/language.content_settings.redirect.redirect.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - redirect
+id: redirect.redirect
+target_entity_type_id: redirect
+target_bundle: redirect
+default_langcode: und
+language_alterable: true

--- a/config/install/language.entity.en.yml
+++ b/config/install/language.entity.en.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: en
+label: English
+direction: ltr
+weight: 0
+locked: false

--- a/config/install/language.entity.und.yml
+++ b/config/install/language.entity.und.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: und
+label: 'Not specified'
+direction: ltr
+weight: 2
+locked: true

--- a/config/install/language.entity.zxx.yml
+++ b/config/install/language.entity.zxx.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: zxx
+label: 'Not applicable'
+direction: ltr
+weight: 3
+locked: true

--- a/config/install/language.mappings.yml
+++ b/config/install/language.mappings.yml
@@ -1,0 +1,11 @@
+map:
+  'no': nb
+  pt: pt-pt
+  zh: zh-hans
+  zh-tw: zh-hant
+  zh-hk: zh-hant
+  zh-mo: zh-hant
+  zh-cht: zh-hant
+  zh-cn: zh-hans
+  zh-sg: zh-hans
+  zh-chs: zh-hans

--- a/config/install/language.negotiation.yml
+++ b/config/install/language.negotiation.yml
@@ -1,0 +1,9 @@
+session:
+  parameter: language
+url:
+  source: path_prefix
+  prefixes:
+    en: ''
+  domains:
+    en: ''
+selected_langcode: site_default

--- a/config/install/language.types.yml
+++ b/config/install/language.types.yml
@@ -1,0 +1,17 @@
+all:
+  - language_interface
+  - language_content
+  - language_url
+configurable:
+  - language_interface
+negotiation:
+  language_content:
+    enabled:
+      language-interface: 0
+  language_url:
+    enabled:
+      language-url: 0
+      language-url-fallback: 1
+  language_interface:
+    enabled:
+      language-url: 0


### PR DESCRIPTION
# [AS-82](https://manati.atlassian.net/browse/AS-82)

- Added the `language` module config.
- Enabled the `field_ui` module in production, because is required by `layout_builder`
- Updated the `components` module config.
- Changed the `search_api_solr` from 3.9 to 4.
- Added the config flag to the `composer.json` file to stop patching when error appears. 

# Steps to test
- [ ] Clone project and switch to branch
- [ ] Move the cloned folder to the profiles folder
- [ ] Add all the needed config listed in the [README](https://github.com/ManatiCR/trichechus/blob/feature/update-profle-config/README.md) file
- [ ] Install the Drupal site using this profile and confirm everything is ok.
- [ ] Go to `/admin/config/development/configuration/config-split` and confirm the `field_ui` module isn't in the **dev** config.
