### PR TITLE
AS-14: Add Google Analytics and delete LB Modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ This project contains several modules commonly used in Manati projects:
 
 - admin_toolbar
 - admin_toolbar_tools
-- analytics
 - better_exposed_filters
 - components
 - config_split
@@ -29,11 +28,11 @@ This project contains several modules commonly used in Manati projects:
 - entity_embed
 - environment_indicator
 - focal_point
+- google_analytics
 - honeypot
 - image_style_quality
 - inline_entity_form
 - layout_builder_browser
-- layout_builder_modal
 - layout_builder_restrictions
 - media_entity_browser
 - media_entity_facebook

--- a/composer.json
+++ b/composer.json
@@ -73,13 +73,12 @@
     "drupal/retina_images": "1.x-dev",
     "drupal/smtp": "^1.0",
     "drupal/shs": "^1.0",
-    "drupal/analytics": "^1.0",
+    "drupal/google_analytics": "^3.0",
     "drupal/warmer": "^1.1",
     "drupal/search_api_solr": "^4.0",
     "drupal/redis": "^1.4",
     "drupal/url_embed": "^1.0",
     "drupal/layout_builder_restrictions": "^2.7",
-    "drupal/layout_builder_modal": "^1.1",
     "drupal/layout_builder_browser": "^1.0"
   },
   "require-dev": {

--- a/config/install/analytics.settings.yml
+++ b/config/install/analytics.settings.yml
@@ -1,6 +1,0 @@
-privacy:
-  dnt: true
-  anonymize_ip: false
-cache_urls: false
-disable_page_build: false
-

--- a/config/install/google_analytics.settings.yml
+++ b/config/install/google_analytics.settings.yml
@@ -1,0 +1,35 @@
+account: ''
+premium: false
+domain_mode: 0
+cross_domains: ''
+visibility:
+  request_path_mode: 0
+  request_path_pages: "/admin\n/admin/*\n/batch\n/node/add*\n/node/*/*\n/user/*/*"
+  user_role_mode: 0
+  user_role_roles: {  }
+  user_account_mode: 0
+track:
+  outbound: true
+  mailto: true
+  files: true
+  files_extensions: '7z|aac|arc|arj|asf|asx|avi|bin|csv|doc(x|m)?|dot(x|m)?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt(x|m)?|pot(x|m)?|pps(x|m)?|ppam|sld(x|m)?|thmx|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls(x|m|b)?|xlt(x|m)|xlam|xml|z|zip'
+  colorbox: true
+  linkid: false
+  urlfragments: false
+  userid: false
+  messages: {  }
+  site_search: false
+  adsense: false
+  displayfeatures: true
+privacy:
+  anonymizeip: true
+custom:
+  dimension: {  }
+  metric: {  }
+codesnippet:
+  create: {  }
+  before: ''
+  after: ''
+translation_set: false
+cache: false
+debug: false

--- a/config/install/layout_builder_modal.settings.yml
+++ b/config/install/layout_builder_modal.settings.yml
@@ -1,4 +1,0 @@
-modal_width: 768
-modal_height: auto
-modal_autoresize: true
-theme_display: default_theme

--- a/trichechus.info.yml
+++ b/trichechus.info.yml
@@ -9,7 +9,6 @@ dependencies:
   - admin_toolbar
   - admin_toolbar_links_access_filter
   - admin_toolbar_tools
-  - analytics
   - better_exposed_filters
   - block
   - block_content
@@ -40,6 +39,7 @@ dependencies:
   - file
   - filter
   - focal_point
+  - google_analytics
   - help
   - honeypot
   - image
@@ -49,7 +49,6 @@ dependencies:
   - kint
   - layout_builder
   - layout_builder_browser
-  - layout_builder_modal
   - link
   - media_entity_browser
   - media_entity_facebook


### PR DESCRIPTION
# [AS-14](https://manati.atlassian.net/browse/AS-14), [AS-87](https://manati.atlassian.net/browse/AS-87)

- Added the `google_analytics` module and config.
- Deleted `analytics` and `layout_builder_modal` modules

## Steps to test
- [ ] Clone project and switch to branch
- [ ] Move the cloned folder to the profiles folder
- [ ] Add all the needed config listed in the [README](https://github.com/ManatiCR/trichechus/blob/feature/update-profle-config/README.md) file
- [ ] Install the Drupal site using this profile and confirm everything is ok.
- [ ] Go to `/admin/modules` and confirm there's not the layout builder module or analytics module.
- [ ] Go to `/admin/config/system/google-analytics` and confirm there's a basic info for Google Analytics Module