### PR TITLE
BLM-20: Remove emulsify dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - COMPOSER_MEMORY_LIMIT=-1 COMPOSER_MIRROR_PATH_REPOS=1
 before_install:
   - cd ~
-  - composer create-project drupal/recommended-project:~8.8.0 trichechus-test --stability dev --no-interaction
+  - composer create-project drupal/recommended-project:~8.9.0 trichechus-test --stability dev --no-interaction
   - cd trichechus-test
   - composer config repositories.trichechus path $TRAVIS_BUILD_DIR
   - composer config extra.enable-patching true

--- a/composer.json
+++ b/composer.json
@@ -65,8 +65,6 @@
     "drupal/media_entity_facebook": "^2.0",
     "drupal/media_entity_twitter": "^2.4",
     "drupal/media_entity_instagram": "^2.0",
-    "emulsify-ds/emulsify-drupal": "^1.0@beta",
-    "drupal/components": "^1.0",
     "drupal/redirect": "^1.6",
     "drupal/quicklink": "^1.2",
     "drupal/image_style_quality": "^1.3",

--- a/trichechus.info.yml
+++ b/trichechus.info.yml
@@ -16,7 +16,6 @@ dependencies:
   - breakpoint
   - ckeditor
   - color
-  - components
   - config
   - config_split
   - contact
@@ -32,7 +31,6 @@ dependencies:
   - dropzonejs
   - dropzonejs_eb_widget
   - editor
-  - emulsify_twig
   - entity_embed
   - entity_reference
   - environment_indicator


### PR DESCRIPTION
# [BLM-20](https://manati.atlassian.net/browse/BLM-20)

- Remove the emulsify dependencies.


## Steps to test
- [ ] Clone project and switch to branch
- [ ] Move the cloned folder to the profiles folder
- [ ] Add all the needed config listed in the [README](https://github.com/ManatiCR/trichechus/blob/feature/update-profle-config/README.md) file
- [ ] Install the Drupal site using this profile and confirm everything is ok.
- [ ] Go to `/admin/modules` and confirm there's not the emulsify modules.
- [ ] Go to `/admin/modules` and confirm there's not the emulsify base theme.